### PR TITLE
Add end date for Tampa CVP and other minor edits to sandbox web UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,11 +84,12 @@ permissions and limitations under the License.
                         <div class="panel-body">
                             <p>
                               This S3 bucket contains sanitized raw data from the <a href="https://www.its.dot.gov/pilots/" target="_blank" rel="noopener noreferrer">Connected Vehicles (CV) Pilot Programs</a>.
-                              Each file is a newline JSON file containing multiple messages. You may access the files in this this bucket by downloading them in the file explorer below or <a href="https://github.com/usdot-its-jpo-data-portal/sandbox#accessing-cv-pilots-data-from-a-public-amazon-s3-bucket" target="_blank" rel="noopener noreferrer">via command line or code</a>.
+                              Each file is a newline JSON file containing multiple messages. You may access the files in this this bucket by downloading them in the file explorer below or via <a href="https://github.com/usdot-its-jpo-data-portal/sandbox" target="_blank" rel="noopener noreferrer">command line or code</a>.
                               An overview of open data resources related to the Connected Vehicle Pilot can be found in this <a href="https://data.transportation.gov/stories/s/Connected-Vehicle-Pilot-Sandbox/hr8h-ufhq" target="_blank" rel="noopener noreferrer">data story</a>.
                             </p><p></p>
                             <p>
-                              Please see change notes relating to any major changes to the data at the <a href="https://github.com/usdot-its-jpo-data-portal/cv_pilot_ingest/wiki/ITS-CV-Pilot-Sandbox-Data-Change-Notes" target="_blank" rel="noopener noreferrer">cv_pilot_ingest GitHub repository wiki page</a>.
+                              Please see change notes relating to any major changes to the data at the <a href="https://github.com/usdot-its-jpo-data-portal/cv_pilot_ingest/wiki/ITS-CV-Pilot-Sandbox-Data-Change-Notes" target="_blank" rel="noopener noreferrer">cv_pilot_ingest GitHub repository wiki page</a>
+                              and consult our log of <a href="https://github.com/usdot-its-jpo-data-portal/sandbox/wiki/ITS-CV-Pilot-Data-Sandbox-Known-Data-Gaps-and-Caveats" target="_blank" rel="noopener noreferrer">known data pipeline downtime and caveats</a> prior to using the data.
                               The data held here are not affected by the interventions of the CV pilot, and thus the data can be analyzed without accounting for the baseline/test periods.
                             </p>
                             <table class="table table-bordered table-hover table-striped dataTable no-footer" style="width: auto;">
@@ -111,13 +112,13 @@ permissions and limitations under the License.
                                         <td>Tampa-Hillsborough Expressway Authority (thea)</td>
                                         <td>BSM, TIM, and SPAT, compliant with J2735 specification</td>
                                         <td>Nightly</td>
-                                        <td>01/14/2019 - present</td>
+                                        <td>01/14/2019 - 03/19/2021</td>
                                     </tr>
                                     <tr>
                                         <td>New York City DOT (nycdot)</td>
                                         <td>TBD</td>
                                         <td>TBD</td>
-                                        <td>TBD in 2020</td>
+                                        <td>TBD</td>
                                     </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
[RDAODTD-2392](https://usdotjpoode.atlassian.net/browse/RDAODTD-2392)
This PR makes the following edits to the CVP sandbox web UI:
- add an end date to Tampa CVP
- add a link to pipeline downtime + caveat wiki page
- update the link for instructions on how to access the data